### PR TITLE
feat: add depend

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+distrobox (1.4.2.1-1deepin1) unstable; urgency=medium
+
+  * add depend docker-ce to control
+
+ -- chenchongbiao <chenchongbiao@deepin.org>  Mon, 11 Sep 2023 10:55:41 +0800
+
 distrobox (1.4.2.1-1deepin) unstable; urgency=medium
 
   * update changelog.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Rules-Requires-Root: no
 Package: distrobox
 Architecture: all
 Depends:
- podman | docker.io,
+ podman | docker.io | docker-ce,
  ${misc:Depends},
 Description: Another tool for containerized command line environments on Linux
  Use any Linux distribution inside your terminal. Distrobox uses podman or


### PR DESCRIPTION
添加了 distrobox 依赖 docker-ce,docker.io是社区维护的版本，docker-ce是官方提供的社区版本，我们不对docker-ce进行打包维护，不过用户可以自己去使用官方提供的 docker-ce,这里添加 distrobox 对 docker-ce的支持

Log: add depend